### PR TITLE
feat: export `Hunk` and `Line` types

### DIFF
--- a/export.go
+++ b/export.go
@@ -3,6 +3,12 @@ package udiff
 // UnifiedDiff is a unified diff.
 type UnifiedDiff = unified
 
+// Hunk represents a single hunk in a unified diff.
+type Hunk = hunk
+
+// Line represents a single line in a hunk.
+type Line = line
+
 // ToUnifiedDiff takes a file contents and a sequence of edits, and calculates
 // a unified diff that represents those edits.
 func ToUnifiedDiff(fromName, toName string, content string, edits []Edit, contextLines int) (UnifiedDiff, error) {


### PR DESCRIPTION
`Unified` contains a slice of `hunk`, which contain a slice of `line`. Not having these two types exported makes it annoying to use by external packages, because we can't reference these types directly.